### PR TITLE
Exclude file, log.file; fix clippy warnings

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -81,7 +81,7 @@ impl Environment {
         Self { id }
     }
 
-    pub fn as_str<'a>(&'a self) -> &'a str {
+    pub fn as_str(&self) -> &str {
         &self.id
     }
 }

--- a/src/contracts/pool.rs
+++ b/src/contracts/pool.rs
@@ -59,9 +59,9 @@ impl Pool {
 
         Ok(Self {
             contract,
-            web3: web3.clone(),
+            web3,
             key,
-            gas_limit: config.gas_limit.map(|gas_limit| U256::from(gas_limit)),
+            gas_limit: config.gas_limit.map(U256::from),
             transact_short_signature: short_signature,
             timeout: Duration::from_secs(config.provider_timeout_sec),
         })

--- a/src/relayer/client.rs
+++ b/src/relayer/client.rs
@@ -6,7 +6,7 @@ use super::{
     types::{FeeResponse, InfoResponse, JobResponse, TransactionRequest, TransactionResponse},
 };
 
-pub const LIB_VERSION: &'static str = "2.0.2";
+pub const LIB_VERSION: &str = "2.0.2";
 
 pub struct RelayerClient {
     url: String,

--- a/src/telemetry/telemetry.rs
+++ b/src/telemetry/telemetry.rs
@@ -9,7 +9,9 @@ pub fn init_stdout(name: String, env_filter: String) {
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(env_filter));
 
-    let formatting_layer = BunyanFormattingLayer::new(name, || std::io::stdout());
+    let formatting_layer = BunyanFormattingLayer::new(name, std::io::stdout)
+        .skip_fields(vec!["file", "log.file"].into_iter())
+        .expect("One of the specified fields cannot be skipped");
     Registry::default()
         .with(env_filter)
         .with(formatting_layer)
@@ -21,7 +23,7 @@ pub fn init_sink(name: String, env_filter: String) {
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(env_filter));
 
-    let formatting_layer = BunyanFormattingLayer::new(name, || std::io::sink());
+    let formatting_layer = BunyanFormattingLayer::new(name, std::io::sink);
     Registry::default()
         .with(env_filter)
         .with(formatting_layer)


### PR DESCRIPTION
* Exclude lines `file`, `log.file` from logs
* Fix some clippy warnings